### PR TITLE
Move TimeZoneApi execution from Main thread to IO

### DIFF
--- a/leku/src/main/java/com/schibstedspain/leku/geocoder/GeocoderPresenter.kt
+++ b/leku/src/main/java/com/schibstedspain/leku/geocoder/GeocoderPresenter.kt
@@ -113,11 +113,12 @@ class GeocoderPresenter @JvmOverloads constructor(
     fun getInfoFromLocation(latLng: LatLng) {
         view?.willGetLocationInfo(latLng)
         val disposable = geocoderRepository.getFromLocation(latLng)
-                .observeOn(scheduler)
+                .observeOn(Schedulers.io())
                 .retry(RETRY_COUNT.toLong())
                 .filter { addresses -> addresses.isNotEmpty() }
                 .map { addresses -> addresses[0] }
                 .flatMap { address -> returnTimeZone(address) }
+                .observeOn(scheduler)
                 .subscribe({ pair: Pair<Address, TimeZone?> -> view?.showLocationInfo(pair) },
                         { view?.showGetLocationInfoError() },
                         { view?.didGetLocationInfo() })


### PR DESCRIPTION
For some reason TimeZoneApi was being ran on Main thread unlike other network calls resulting in ANRs


## ISSUE
https://github.com/AdevintaSpain/Leku/issues/317

## Description
Moved the execution of TimeZoneApi call to io thread

## Screenshots
Before | After

## Mandatory GIF
![mandatory](https://media.giphy.com/media/1Fuk0EbGP7JbG/giphy.gif)